### PR TITLE
[Feature] Add Customizable Sail Project Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ adapters = {
         -- -- Default: "vendor/bin/sail"
         sail_executable = "vendor/bin/sail",
 
+        -- Custom sail project root path.
+        -- -- Default: "/var/www/html"
+        sail_project_path = "/var/www/html",
+
         -- Custom pest binary.
         -- -- Default: function that checks for sail presence
         pest_cmd = "vendor/bin/pest",

--- a/lua/neotest-pest/config.lua
+++ b/lua/neotest-pest/config.lua
@@ -15,6 +15,7 @@ local M = {
         ignore_dirs = { "vendor", "node_modules" },
         test_file_suffixes = { "Test.php" },
         sail_executable = "vendor/bin/sail",
+        sail_project_path = "/var/www/html",
         parallel = 0,
         compact = false,
     },

--- a/lua/neotest-pest/init.lua
+++ b/lua/neotest-pest/init.lua
@@ -104,7 +104,7 @@ function NeotestAdapter.build_spec(args)
 
     if config('sail_enabled') then
         debug("Sail enabled, adjusting path")
-        path = "/var/www/html" .. string.sub(position.path, string.len(vim.loop.cwd() or "") + 1)
+        path = config('sail_project_path') .. string.sub(position.path, string.len(vim.loop.cwd() or "") + 1)
     end
 
     local command = vim.tbl_flatten({


### PR DESCRIPTION
This PR adds support for a customizable Sail project path, which is currently hardcoded to `/var/www/html`.

I needed this change for a project I'm working on where the root project path inside the docker container is not set to `/var/www/html`.