### PR TITLE
Update Treesitter Queries to Use string_content

### DIFF
--- a/lua/neotest-pest/init.lua
+++ b/lua/neotest-pest/init.lua
@@ -76,13 +76,13 @@ function NeotestAdapter.discover_positions(path)
         ((expression_statement
             (member_call_expression
                 name: (name) @member_name (#eq? @member_name "group")
-                arguments: (arguments . (argument (string (string_value) @namespace.name)))
+                arguments: (arguments . (argument (string (string_content) @namespace.name)))
             ) @member
         )) @namespace.definition
 
         ((function_call_expression
             function: (name) @func_name (#match? @func_name "^(test|it)$")
-            arguments: (arguments . (argument (string (string_value) @test.name)))
+            arguments: (arguments . (argument (string (string_content) @test.name)))
         )) @test.definition
     ]]
 


### PR DESCRIPTION
# Update Treesitter Query

This PR updates the Treesitter query in `lua/neotest-pest/init.lua` to use `string_content` instead of `string_value` when capturing the content inside string literals. This change is necessary to ensure compatibility with the latest version of nvim-treesitter.

Please let me know if you have any questions or feedback.