### PR TITLE
Update LazyVim example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,25 @@ Install the plugin using your favorite package manager.
 
 Here's an example using lazy.nvim:
 
+
+```
+~/.config/nvim/lua/plugins/pest.lua
+```
 ```lua
-{
-    'nvim-neotest/neotest',
-    dependencies = {
-        ...,
-        'V13Axel/neotest-pest',
+return {
+  {
+    "V13Axel/neotest-pest",
+  },
+  {
+    "nvim-neotest/neotest",
+    opts = {
+      adapters = {
+        ["neotest-pest"] = {
+          -- Config Options
+        },
+      },
     },
-    config = function()
-        require('neotest').setup({
-            ...,
-            adapters = {
-                require('neotest-pest'),
-            }
-        })
-    end
+  },
 }
 ```
 


### PR DESCRIPTION
I'm submitting this change for 2 reasons:

1. This may be a result of my naïveté to LazyVim/NeoVim (I just started using them a few days ago), but the LazyVim docs say in the formatting section "Don't set `plugin.config` for `conform.nvim`.\n". Obviously, this repo is not about formatting, but it seems like the pattern they want LazyVim users to use is a plugin, not editing the NeoTest config directly.
2. I couldn't get this example to work. LazyVim would complain that the config being passed to NeoTest was missing options (my installation is fresh and doesn't have any other testing libs). It took me a while, but I finally got it working using the changeset provided here.

Hopefully, this is helpful.