### PR TITLE
Fixed Docker error on running full testsuite

### DIFF
--- a/lua/neotest-pest/init.lua
+++ b/lua/neotest-pest/init.lua
@@ -113,6 +113,10 @@ function NeotestAdapter.build_spec(args)
     if config('sail_enabled') then
         debug("Sail enabled, adjusting path")
         path = config('sail_project_path') .. string.sub(position.path, string.len(vim.loop.cwd() or "") + 1)
+
+        if position.type == "dir" then
+            path = ""
+        end
     end
 
     local command = vim.tbl_flatten({


### PR DESCRIPTION
When running the full testsuite it gives an error on sail/docker images.

I noticed that when neotest-pest specifies a full test run it tries to run pest on the sail/docker directory which ignores the phpunit.xml includes. This will mean that it tries to run **all** tests, including the vendor directory.

So I tried running the tests like the program is trying to do:
`vendor/bin/pest /var/www/html --parallel` (gives an error because its trying to run vendor tests)
`vendor/bin/pest --parallel` (works fine)

Fixed it by disabling the path component when running sail/docker. Not sure if this fix is necessary for local development, if it is then we can always move that little piece of code outside the sail-enabled check.